### PR TITLE
Fix generated wake word model manifest

### DIFF
--- a/custom_components/echolocal/wakewords.py
+++ b/custom_components/echolocal/wakewords.py
@@ -170,6 +170,7 @@ class WakeWordUploadView(HomeAssistantView):
         spoken = fields.get("wake_word") or stem.replace("_", " ").replace("-", " ").strip()
 
         config = {
+            "model": f"{wake_id}.tflite",
             "type": fields.get("type") or DEFAULT_TYPE,
             "wake_word": spoken,
             "trained_languages": [


### PR DESCRIPTION
## Summary

Include the uploaded `.tflite` filename in the generated wake-word sidecar as the `model` field.

## Problem

The upload view currently creates a sidecar containing `type`, `wake_word`, and `trained_languages`, but no `model`. Home Assistant still advertises the wake word, so it appears in the device picker. When selected, EchoLocal fetches the sidecar and rejects it because it does not name a model. The device consequently reports no accepted wake word and Home Assistant immediately reverts the selection to `no_wake_word`.

Adding, for example, `"model": "computer_v2.tflite"` to the generated JSON allows EchoLocal to adopt and load the model successfully.

## Validation

Reproduced with:

- Home Assistant Core 2026.8.0
- EchoLocal 0.0.1 on a second-generation Echo Dot
- `computer_v2.tflite` OpenWakeWord model

Before the sidecar fix, selecting the model immediately reverted to no wake word. Adding the missing field and restarting Home Assistant made the model load and remain selected.

The Python component compiles successfully and the diff passes `git diff --check`. The repository does not currently include a Python unit-test job.