### PR TITLE
Fix wake word cache invalidation

### DIFF
--- a/custom_components/echolocal/wakewords.py
+++ b/custom_components/echolocal/wakewords.py
@@ -20,6 +20,7 @@ from typing import Any
 import voluptuous as vol
 from aiohttp import web
 from homeassistant.components import websocket_api
+from homeassistant.components.esphome import assist_satellite as esphome_satellite
 from homeassistant.components.esphome.const import (
     WAKE_WORDS_API_PATH,
     WAKE_WORDS_DIR_NAME,
@@ -63,6 +64,12 @@ def _dir(hass: HomeAssistant) -> Path:
 def async_invalidate(hass: HomeAssistant) -> None:
     """Drop core's cached listing. It re-reads on its next connect or set_wake_words."""
     hass.data.pop(CACHE_KEY, None)
+
+    # Core's sync @singleton also wraps the loader in functools.lru_cache, which returns its
+    # own result without looking at hass.data. Clear that as well or the pop above does nothing.
+    cache_clear = getattr(esphome_satellite._get_custom_wake_words, "cache_clear", None)
+    if cache_clear is not None:
+        cache_clear()
 
 
 def _read(store: Path) -> list[dict[str, Any]]:


### PR DESCRIPTION
Uploading a wake word through the manager writes the files fine, but the device never gets offered it. The Dot keeps logging `wake words offered count=0` on every reconnect, and the only thing that fixes it is restarting HA.

The cause is in core. `@singleton` wraps sync functions in `functools.lru_cache(maxsize=1)` (see `homeassistant/helpers/singleton.py`). The wrapped function returns its cached result without ever looking at `hass.data`, so popping `wake_word_cache` on its own does nothing. The listing core built at boot is what gets sent forever.

This adds a call to the wrapper's `cache_clear()` alongside the existing pop. It is guarded with `getattr` so it stays a no-op if core ever drops the wrapper.

Tested on HA 2026.9.0 with echod 0.0.6 on a 2nd gen Dot:

- before: added two models, toggled a wake word in the manager, reloaded the ESPHome entry, still `count=0`
- after: same steps, log shows `wake words offered count=2` and both appear in the wake word select without a restart

`ruff check` and `ruff format --check` pass.
